### PR TITLE
Fix issue where framework couldn't be embedded in app product

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		082D24222943A6F100DAAC5A /* LottieLogo1.json in Resources */ = {isa = PBXBuildFile; fileRef = 082D241A2943A6F000DAAC5A /* LottieLogo1.json */; };
 		082D24232943A6F100DAAC5A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082D241B2943A6F000DAAC5A /* AppDelegate.swift */; };
 		082D24252943A6F100DAAC5A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082D241D2943A6F000DAAC5A /* SceneDelegate.swift */; };
+		2E11D9B5297ADDDC00662020 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 2E11D9B4297ADDDC00662020 /* Lottie */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +34,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2E11D9B5297ADDDC00662020 /* Lottie in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -44,6 +46,7 @@
 			children = (
 				082D24132943A6F000DAAC5A /* Example */,
 				082D23EC2943A62100DAAC5A /* Products */,
+				2E11D9AD297ADBA900662020 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -70,6 +73,13 @@
 			path = Example;
 			sourceTree = "<group>";
 		};
+		2E11D9AD297ADBA900662020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -87,6 +97,7 @@
 			);
 			name = Example;
 			packageProductDependencies = (
+				2E11D9B4297ADDDC00662020 /* Lottie */,
 			);
 			productName = Example;
 			productReference = 082D23EB2943A62100DAAC5A /* Example.app */;
@@ -295,6 +306,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Example/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -322,6 +334,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Example/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -364,6 +377,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2E11D9B4297ADDDC00662020 /* Lottie */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Lottie;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 082D23E32943A62100DAAC5A /* Project object */;
 }

--- a/Package.swift
+++ b/Package.swift
@@ -5,12 +5,20 @@ import PackageDescription
 let package = Package(
   name: "Lottie",
   platforms: [.iOS("11.0"), .macOS("10.10"), .tvOS("11.0")],
-  products: [.library(name: "Lottie", targets: ["Lottie"])],
+  products: [.library(name: "Lottie", targets: ["Lottie", "_LottieStub"])],
   targets: [
     .binaryTarget(
       name: "Lottie",
       url: "https://github.com/airbnb/lottie-ios/releases/download/4.1.0/Lottie.xcframework.zip",
       checksum: "e954f5bfc5049196593c59c6eb21321016ffaba4417e9b4ece2a6a9eb54baa9a"),
+    
+    // Without at least one regular (non-binary) target, this package doesn't show up
+    // in Xcode under "Frameworks, Libraries, and Embedded Content". That prevents
+    // Lottie from being embedded in the app product, causing the app to crash when
+    // ran on a physical device. As a workaround, we can include a stub target
+    // with at least one source file.
+    .target(name: "_LottieStub"),
+    
     .testTarget(
       name: "LottieTests",
       dependencies: ["Lottie"],

--- a/Sources/_LottieStub/Stub.swift
+++ b/Sources/_LottieStub/Stub.swift
@@ -1,0 +1,4 @@
+// Created by Cal Stephens on 1/20/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+import Lottie


### PR DESCRIPTION
This PR fixes an issue where the framework built from this package couldn't be embedded in the final app product. This was causing apps to crash when ran on a physical device. Fixes https://github.com/airbnb/lottie-ios/issues/1925. Fixes https://github.com/airbnb/lottie-ios/issues/1926.

| Before | After |
| ----- | ------ |
| <img width="421" alt="Screenshot 2023-01-20 at 6 29 57 AM" src="https://user-images.githubusercontent.com/1811727/213724871-8655094c-68d9-4c7d-bfd8-8c24a062cb42.png"> | <img width="416" alt="Screenshot 2023-01-20 at 6 38 26 AM" src="https://user-images.githubusercontent.com/1811727/213725218-7bd5e75c-f418-44bd-a53f-dc11d9592474.png"> |