### PR TITLE
Remove `import Lottie` from _LottieStub module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or you can add the following dependency to your `Package.swift`:
 
 ### Why is there a separate repo for Swift Package Manager support?
 
-The main git repository for [lottie-ios](https://github.com/airbnb/lottie-ios) is somewhat large (300+ MB), and Swift Package Manager always downloads the full repository with all git hsitory. This [lottie-spm](https://github.com/airbnb/lottie-spm) repo is much smaller (less than 500kb), so can be downloaded much more quickly. 
+The main git repository for [lottie-ios](https://github.com/airbnb/lottie-ios) is somewhat large (300+ MB), and Swift Package Manager always downloads the full repository with all git history. This [lottie-spm](https://github.com/airbnb/lottie-spm) repo is much smaller (less than 500kb), so can be downloaded much more quickly.
 
 Instead of downloading the full git history of Lottie and building it from source, this repo just contains a pointer to the precompiled XCFramework included in the [latest lottie-ios release](https://github.com/airbnb/lottie-ios/releases/latest) (typically ~8MB). If you prefer to include Lottie source directly your project, you can directly depend on the [`lottie-ios` repo](https://github.com/airbnb/lottie-ios) instead.
 

--- a/Sources/_LottieStub/Stub.swift
+++ b/Sources/_LottieStub/Stub.swift
@@ -1,4 +1,4 @@
 // Created by Cal Stephens on 1/20/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Lottie
+class LottieStub { } 


### PR DESCRIPTION
This PR removes `import Lottie` from the `_LottieStub` module. This wasn't actually necessary, it was just the first placeholder code that came to mind when I was setting it up. Removing this fixes issues where this package would fail to build in some circumstances: https://github.com/airbnb/lottie-spm/pull/5#issuecomment-1399216739, https://github.com/airbnb/lottie-ios/issues/1926#issuecomment-1398866563