### PR TITLE
Update binary target to lottie-ios 4.1.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "Lottie",
-      url: "https://github.com/airbnb/lottie-ios/releases/download/4.1.1/Lottie.xcframework.zip",
-      checksum: "a49664f0482fbdd51d258a7bb77b95dfb76c2688f2e55b65bd7620facc390f0b"),
+      url: "https://github.com/airbnb/lottie-ios/releases/download/4.1.2/Lottie.xcframework.zip",
+      checksum: "3fc1e8054e3749caee0ae189770b6793a6ab3292b4d9d8fd1b8762265339c14b"),
     
     // Without at least one regular (non-binary) target, this package doesn't show up
     // in Xcode under "Frameworks, Libraries, and Embedded Content". That prevents

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install Lottie using [Swift Package Manager](https://github.com/apple/swift-p
 or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.1.1")
+.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.1.2")
 ```
 
 ### Why is there a separate repo for Swift Package Manager support?


### PR DESCRIPTION
This PR updates the binary target to lottie-ios 4.1.2