### PR TITLE
Bump XCFramework pointer to lottie-ios 4.1.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
       - name: Build Example
-        run: bundle exec rake build:example:all
+        run: bundle exec rake build:example:github_actions

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "Lottie",
-      url: "https://github.com/airbnb/lottie-ios/releases/download/4.1.2/Lottie.xcframework.zip",
-      checksum: "3fc1e8054e3749caee0ae189770b6793a6ab3292b4d9d8fd1b8762265339c14b"),
+      url: "https://github.com/airbnb/lottie-ios/releases/download/4.1.3/Lottie.xcframework.zip",
+      checksum: "31ab682ec2c7b49e8a59458f7e4cfa027a07d8ba962df0ddcb95909ce5a9693d"),
     
     // Without at least one regular (non-binary) target, this package doesn't show up
     // in Xcode under "Frameworks, Libraries, and Embedded Content". That prevents

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install Lottie using [Swift Package Manager](https://github.com/apple/swift-p
 or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.1.2")
+.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.1.3")
 ```
 
 ### Why is there a separate repo for Swift Package Manager support?

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,11 @@
 namespace :build do
   desc 'Builds the Lottie example app'
   namespace :example do
+    desc 'Builds the Example apps for all supported platforms / architectures. Requires valid code signing.'
     task all: ['iOS:simulator', 'iOS:device', 'macOS:arm64', 'macOS:x86_64', 'macCatalyst:arm64', 'macCatalyst:x86_64']
+
+    desc 'Builds the Example app for platforms / architectures supported by Github Actions CI'
+    task github_actions: ['iOS:simulator', 'macOS:x86_64']
 
     namespace :iOS do
       task :simulator do


### PR DESCRIPTION
This PR bumps the `Lottie.xcframework` pointer to [`lottie-ios` 4.1.3](https://github.com/airbnb/lottie-ios/releases/tag/4.1.3)