### PR TITLE
Update XCFramework reference to lottie-ios 4.3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
         xcode:
         - '14.2' # Swift 5.7
         - '14.3' # Swift 5.8
+        - '15.0' # Swift 5.9
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,16 +7,31 @@ on:
     branches: [ main ]
 
 jobs:
-  test-package:
+  Test-package-macos-12:
     name: "Test Package"
     runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:
         xcode:
-        - '13.2.1' # Swift 5.5
         - '13.4.1' # Swift 5.6
-        - '14.0.1' # Swift 5.7
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup
+        with:
+          xcode: ${{ matrix.xcode }}
+      - name: Build Package
+        run: bundle exec rake test:package:all
+
+  Test-package-macos-13:
+    name: "Test Package"
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode:
+        - '14.2' # Swift 5.7
+        - '14.3' # Swift 5.8
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "Lottie",
-      url: "https://github.com/airbnb/lottie-ios/releases/download/4.2.0/Lottie.xcframework.zip",
-      checksum: "4db3dee208f6213e5c1681f2314c7ed96d466d9b9adfe5cd0030309515075443"),
+      url: "https://github.com/airbnb/lottie-ios/releases/download/4.3.0/Lottie.xcframework.zip",
+      checksum: "5a30896b74a693f36269d3ea32401fecb3826dfa9d667ea4f1b9a788c3e5c150"),
     
     // Without at least one regular (non-binary) target, this package doesn't show up
     // in Xcode under "Frameworks, Libraries, and Embedded Content". That prevents

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install Lottie using [Swift Package Manager](https://github.com/apple/swift-p
 or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.2.0")
+.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.3.0")
 ```
 
 ### Why is there a separate repo for Swift Package Manager support?

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ namespace :build do
 
     namespace :iOS do
       task :simulator do
-        xcodebuild('build -scheme "Example (iOS)" -destination "platform=iOS Simulator,name=iPhone 8" -workspace Example/Example.xcworkspace')
+        xcodebuild('build -scheme "Example (iOS)" -destination "platform=iOS Simulator,name=iPhone SE (3rd generation)" -workspace Example/Example.xcworkspace')
       end
       task :device do
         xcodebuild('build -scheme "Example (iOS)" -destination generic/platform=iOS -workspace Example/Example.xcworkspace')
@@ -44,7 +44,7 @@ namespace :test do
 
     desc 'Tests the Lottie package for iOS'
     task :iOS do
-      xcodebuild('test -scheme Lottie -destination "platform=iOS Simulator,name=iPhone 8"')
+      xcodebuild('test -scheme Lottie -destination "platform=iOS Simulator,name=iPhone SE (3rd generation)"')
     end
 
     desc 'Tests the Lottie package for macOS'


### PR DESCRIPTION
This PR updates the XCFramework reference in the `Package.swift` to point to lottie-ios 4.3.0: https://github.com/airbnb/lottie-ios/releases/tag/4.3.0

This PR also drops support for Swift 5.5, which we already did in the lottie-ios repo.