### PR TITLE
Update XCFramework reference to lottie-ios 4.3.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "Lottie",
-      url: "https://github.com/airbnb/lottie-ios/releases/download/4.3.0/Lottie.xcframework.zip",
-      checksum: "5a30896b74a693f36269d3ea32401fecb3826dfa9d667ea4f1b9a788c3e5c150"),
+      url: "https://github.com/airbnb/lottie-ios/releases/download/4.3.1/Lottie.xcframework.zip",
+      checksum: "730e72bd0c7cce97c6cf3f6f9dce523bf8cd2ea35236549a78cbafcc133f7435"),
     
     // Without at least one regular (non-binary) target, this package doesn't show up
     // in Xcode under "Frameworks, Libraries, and Embedded Content". That prevents

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install Lottie using [Swift Package Manager](https://github.com/apple/swift-p
 or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.3.0")
+.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.3.1")
 ```
 
 ### Why is there a separate repo for Swift Package Manager support?


### PR DESCRIPTION
This PR updates the XCFramework reference in `Package.swift` to the lottie-ios 4.3.1 release, and bumps the current version to 4.3.1.