### PR TITLE
Update XCFramework reference to lottie-ios 4.3.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "Lottie",
-      url: "https://github.com/airbnb/lottie-ios/releases/download/4.3.1/Lottie.xcframework.zip",
-      checksum: "730e72bd0c7cce97c6cf3f6f9dce523bf8cd2ea35236549a78cbafcc133f7435"),
+      url: "https://github.com/airbnb/lottie-ios/releases/download/4.3.2/Lottie.xcframework.zip",
+      checksum: "216eb42e7480e40381967b1502748d1fd37dcbd87660233efe7c374ab0c217df"),
     
     // Without at least one regular (non-binary) target, this package doesn't show up
     // in Xcode under "Frameworks, Libraries, and Embedded Content". That prevents

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install Lottie using [Swift Package Manager](https://github.com/apple/swift-p
 or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.3.1")
+.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.3.2")
 ```
 
 ### Why is there a separate repo for Swift Package Manager support?


### PR DESCRIPTION
This PR updates the XCFramework reference in `Package.swift` to lottie-ios 4.3.2