### PR TITLE
Update CI jobs to run on Apple Silicon macOS 14 runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           xcode: ${{ matrix.xcode }}
       - name: Build Package
-        run: SKIP_VISION_OS=true bundle exec rake test:package:all
+        run: SKIP_VISION_OS=true bundle exec rake test:package:github_actions
 
   test-package-macos-13:
     name: "Test Package"
@@ -40,7 +40,7 @@ jobs:
         with:
           xcode: ${{ matrix.xcode }}
       - name: Build Package
-        run: bundle exec rake test:package:all
+        run: bundle exec rake test:package:github_actions
 
   build-example-excluding-visionOS:
     name: "Build Example App"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-package-excluding-visionOS:
     name: "Test Package"
-    runs-on: macos-14
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +44,7 @@ jobs:
 
   build-example-excluding-visionOS:
     name: "Build Example App"
-    runs-on: macos-14
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-package-excluding-visionOS:
     name: "Test Package"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +28,7 @@ jobs:
 
   test-package-macos-13:
     name: "Test Package"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +44,7 @@ jobs:
 
   build-example-excluding-visionOS:
     name: "Build Example App"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +63,7 @@ jobs:
 
   build-example-macos-13:
     name: "Build Example App"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:

--- a/Rakefile
+++ b/Rakefile
@@ -103,10 +103,5 @@ def ifVisionOSEnabled
 end
 
 def installVisionOSIfNecessary
-  # visionOS is unsupported by default on Intel, but we can override this
-  # https://github.com/actions/runner-images/issues/8144#issuecomment-1902072070
-  sh 'defaults write com.apple.dt.Xcode AllowUnsupportedVisionOSHost -bool YES'
-  sh 'defaults write com.apple.CoreSimulator AllowUnsupportedVisionOSHost -bool YES'
-
   xcodebuild("-downloadPlatform visionOS")
 end

--- a/Rakefile
+++ b/Rakefile
@@ -97,11 +97,6 @@ def ifVisionOSEnabled
   if ENV["SKIP_VISION_OS"] == "true"
     puts "Skipping visionOS build"
   else
-    installVisionOSIfNecessary()
     yield
   end
-end
-
-def installVisionOSIfNecessary
-  xcodebuild("-downloadPlatform visionOS")
 end

--- a/Rakefile
+++ b/Rakefile
@@ -56,6 +56,10 @@ namespace :test do
     desc 'Tests the Lottie package for all supported platforms'
     task all: ['iOS', 'macOS', 'tvOS', 'visionOS']
 
+    # The visionOS tests time out in GitHub actions as of Feb 2024, so we exclude them for now.
+    desc 'Tests the Lottie package for all platforms supported by GitHub Actions'
+    task github_actions: ['iOS', 'macOS', 'tvOS']
+
     desc 'Tests the Lottie package for iOS'
     task :iOS do
       xcodebuild('test -scheme Lottie -destination "platform=iOS Simulator,name=iPhone SE (3rd generation)"')


### PR DESCRIPTION
GitHub released a new macOS 14 runner that uses Apple Silicon: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

This PR adopts the new macOS 14 runner. Since we now run our CI jobs on Apple Silicon, we no longer need the workaround for using the visionOS SDK on Intel.