### PR TITLE
Update minimum deployment target to iOS 13.0 / macOS 10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let lottieXCFramework = Target.binaryTarget(
 
 let package = Package(
   name: "Lottie",
-  platforms: [.iOS("11.0"), .macOS("10.11"), .tvOS("11.0"), .custom("visionOS", versionString: "1.0")],
+  platforms: [.iOS("13.0"), .macOS("10.15"), .tvOS("13.0"), .custom("visionOS", versionString: "1.0")],
   products: [.library(name: "Lottie", targets: ["Lottie", "_LottieStub"])],
   targets: [
     lottieXCFramework,


### PR DESCRIPTION
This PR updates the minimum deployment target to iOS 13.0 / macOS 10.15.

This is the same change we made in the lottie-ios repo here: https://github.com/airbnb/lottie-ios/pull/2322