### PR TITLE
Add Privacy Manifest

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>3B52.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -25,3 +25,25 @@ Instead of downloading the full git history of Lottie and building it from sourc
 ### Other Package Managers
 
 Lottie is also available via Cocoapods, Carthage, and npm. You can also build Lottie directly from source, or manually integrate precompiled XCFrameworks into your project. More information is available in the main [lottie-ios](https://github.com/airbnb/lottie-ios#installing-lottie) repo.
+
+### Swift Version Support
+
+Lottie supports Swift / Xcode versions back to the minimum version that is permitted by Apple for submissions to the App Store. You can see the most up-to-date information for which Swift versions Lottie supports on [Swift Package Index](https://swiftpackageindex.com/airbnb/lottie-ios):
+
+[![Swift Versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Flottie-ios%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/lottie-ios)
+
+### Privacy
+
+Lottie does not collect any data. We provide this notice to help you fill out [App Privacy Details](https://developer.apple.com/app-store/app-privacy-details/). We additionally provide a [privacy manifest](https://github.com/airbnb/lottie-spm/blob/master/Sources/PrivacyInfo.xcprivacy) which can be included in your app.
+
+When generating a privacy report, Xcode will automatically detect and use the privacy manifest included in the downloaded `Lottie.xcframework`. For convenience we also provide a copy of the privacy manifest [in this repo](https://github.com/airbnb/lottie-spm/blob/master/PrivacyInfo.xcprivacy).
+
+### Security
+
+We distribute XCFramework bundles for each release on [GitHub](https://github.com/airbnb/lottie-ios/releases/latest). In Lottie 4.4.0 and later, these XCFramework bundles include a [code signature](https://developer.apple.com/documentation/xcode/verifying-the-origin-of-your-xcframeworks). These bundles are self-signed under the name "Lottie iOS" and have the following fingerprint:
+
+```
+89 2F 1B 43 04 7B 50 53 8F 2F 46 EA D9 29 00 DD 3D 48 11 F358 21 78 C0 61 A5 FB 20 F1 11 CB 26
+```
+
+When using lottie-spm, the downloaded `Lottie.xframework` isn't visible in the project navigator. To validate the authenticity of a lottie-spm package, you can confirm that the `Package.swift` file references a binary XCFramework from https://github.com/airbnb/lottie-ios/releases. 


### PR DESCRIPTION
This PR adds a copy of the lottie-ios privacy manifest to this repo.

The binary `Lottie.xcframework` includes a privacy manifest. In https://github.com/airbnb/lottie-ios/discussions/2364#discussioncomment-9007895, we've confirmed this is detected and consumed properly by Xcode. There's been some confusion about this though, since it's not obvious and not documented.

This PR documents how the privacy manifest integration works, and adds a copy of it to this repo for convenience. I also imported a few other relevant sections from lottie-ios's README.