### PR TITLE
Update NSPrivacyAccessedAPITypeReasons in privacy manifest

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -15,7 +15,7 @@
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>3B52.1</string>
+				<string>C617.1</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
lottie-spm companion of lottie-ios PR: https://github.com/airbnb/lottie-ios/pull/2380

-----

Following the recommendation from airbnb/lottie-ios#2371, this updates the `NSPrivacyAccessedAPITypeReasons` in our privacy manifest from:

> [**3B52.1**](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api): Declare this reason to access the timestamps, size, or other metadata of files or directories that the user specifically granted access to, such as using a document picker view controller.

to:

> [**C617.1**](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api): Declare this reason to access the timestamps, size, or other metadata of files inside the app container, app group container, or the app’s CloudKit container.

