### PR TITLE
Remove Linux `#error` from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,9 +38,3 @@ let package = Package(
       dependencies: ["Lottie"],
       path: "Tests")
   ])
-
-// Emit an error on Linux, so Swift Package Manager's platform support detection doesn't say this package supports Linux
-// https://github.com/airbnb/swift/discussions/197#discussioncomment-4055303
-#if os(Linux)
-#error("Linux is currently not supported")
-#endif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Lottie for Swift Package Manager
-[![SwiftPM](https://img.shields.io/badge/SPM-supported-DE5C43.svg?style=flat)](https://swift.org/package-manager/) [![License](https://img.shields.io/cocoapods/l/lottie-ios.svg?style=flat)](https://cocoapods.org/pods/lottie-ios) [![Platform](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Flottie-spm%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/airbnb/lottie-spm) [![Swift Versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Flottie-spm%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/lottie-spm)
+[![SwiftPM](https://img.shields.io/badge/SPM-supported-DE5C43.svg?style=flat)](https://swift.org/package-manager/) [![License](https://img.shields.io/cocoapods/l/lottie-ios.svg?style=flat)](https://cocoapods.org/pods/lottie-ios) [![Swift Versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fairbnb%2Flottie-spm%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/airbnb/lottie-spm)
 
 This repo provides Swift Package Manager support for [lottie-ios](https://github.com/airbnb/lottie-ios). 
 


### PR DESCRIPTION
This PR removes the `#error("Linux is currently not supported")` error from our Package.swift.

This was originally so Swift Package Index wouldn't list this package as supporting Linux. This is causing issues for folks though, since it prevents the Package.manifest from being parsed on Linux (e.g. in CI): https://github.com/airbnb/lottie-ios/discussions/2328

Rather than having this workaround to fix the Swift Package Index badge, let's just remove both.