### PR TITLE
Update Package.swift to reference lottie-ios 4.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         xcode:
-        - '14.2' # Swift 5.7
-        - '14.3' # Swift 5.8
         - '15.0' # Swift 5.9
         - '15.1' # Swift 5.9
     steps:
@@ -49,8 +47,6 @@ jobs:
       fail-fast: false
       matrix:
         xcode:
-        - '14.2' # Swift 5.7
-        - '14.3' # Swift 5.8
         - '15.0' # Swift 5.9
         - '15.1' # Swift 5.9
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -2,21 +2,12 @@
 
 import PackageDescription
 
-#if compiler(>=5.9)
 /// A precompiled XCFramework of the lottie-ios repo that was compiled with Xcode 15.2 / Swift 5.9.
 /// This XCFramework can be used by Xcode 15.0 and later.
 let lottieXCFramework = Target.binaryTarget(
   name: "Lottie",
-  url: "https://github.com/airbnb/lottie-ios/releases/download/4.4.3/Lottie-Xcode-15.2.xcframework.zip",
-  checksum: "546b7e718ed806646b84645ecfb1e1d6a65ac0387ff3f8ecb92dbaf2116cd62c")
-#else
-/// A precompiled XCFramework of the lottie-ios repo that was compiled with Xcode 14.1 / Swift 5.7.
-/// This XCFramework bundle doesn't support visionOS, but does support Xcode 14.
-let lottieXCFramework = Target.binaryTarget(
-  name: "Lottie",
-  url: "https://github.com/airbnb/lottie-ios/releases/download/4.4.3/Lottie-Xcode-14.1.xcframework.zip",
-  checksum: "f068488b56880e95964172797df57358a3354c1540158a5f00988fbe76a41dba")
-#endif
+  url: "https://github.com/airbnb/lottie-ios/releases/download/4.5.0/Lottie.xcframework.zip",
+  checksum: "ea474237ceca92ae12ee276c167f733f75567e9ca144dfa92678dfe5073d77b1")
 
 let package = Package(
   name: "Lottie",


### PR DESCRIPTION
This PR updates the Package.swift manifest to reference lottie-ios 4.5.0.

Lottie now only supports Xcode 15.0 / Swift 5.9 and later, so we can now simplify a few things in this repo as well.