### PR TITLE
ci: declare minimum GITHUB_TOKEN permissions on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test-package:
     name: "Test Package"


### PR DESCRIPTION
Sets the minimum-required `GITHUB_TOKEN` scope on `main.yml`:

- Workflow-level `permissions:` -> `contents: read`
- No changes to jobs, steps, runners, or triggers
- YAML still parses (`yaml.safe_load` succeeds)

Rationale:

- The Swift package CI job is read-only; nothing in it needs write access to the repo.
- Without an explicit block, the run inherits whatever default the repository's actions settings happen to be set to. That default has drifted in the past, and forks-of-forks lose track of it.
- the OpenSSF Scorecard Token-Permissions check flags missing per-workflow permissions as a finding.
- After the tj-actions/changed-files supply-chain incident from March 2025, the cost-benefit on explicit minimum scopes is firmly on the side of declaring them.
